### PR TITLE
Add template CSV import

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -20,8 +20,11 @@
             // Delete commune
             $('.delete-commune').on('click', (e) => this.handleDeleteCommune(e));
             
-            // Import CSV
+            // Import communes CSV
             $('#import-csv').on('change', (e) => this.handleImportCSV(e));
+
+            // Import templates CSV
+            $('#templates-csv-import').on('change', (e) => this.handleImportTemplates(e));
             
             // Template management
             $('.delete-template').on('click', (e) => this.handleDeleteTemplate(e));
@@ -104,6 +107,35 @@
                 success: (response) => {
                     if (response.success) {
                         alert('Import réussi: ' + response.data.imported + ' communes importées');
+                        location.reload();
+                    } else {
+                        alert('Erreur: ' + response.data);
+                    }
+                },
+                error: () => {
+                    alert('Erreur lors de l\'import');
+                }
+            });
+        }
+
+        handleImportTemplates(e) {
+            const file = e.target.files[0];
+            if (!file) return;
+
+            const formData = new FormData();
+            formData.append('csv_file', file);
+            formData.append('action', 'ism_import_templates');
+            formData.append('nonce', $('#ism_admin_nonce').val());
+
+            $.ajax({
+                url: ajaxurl,
+                method: 'POST',
+                data: formData,
+                processData: false,
+                contentType: false,
+                success: (response) => {
+                    if (response.success) {
+                        alert('Import réussi: ' + response.data.imported + ' modèles importés');
                         location.reload();
                     } else {
                         alert('Erreur: ' + response.data);

--- a/interpeller-son-maire.php
+++ b/interpeller-son-maire.php
@@ -111,3 +111,65 @@ class InterpellerSonMaire {
 
 // Initialize plugin
 InterpellerSonMaire::getInstance();
+
+add_action('wp_ajax_ism_import_templates', 'ism_import_templates_callback');
+
+function ism_import_templates_callback() {
+    check_ajax_referer('ism_import_templates', 'nonce');
+
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(__('Accès refusé', 'interpeller-son-maire'));
+    }
+
+    if (empty($_FILES['csv_file']['tmp_name'])) {
+        wp_send_json_error(__('Fichier manquant', 'interpeller-son-maire'));
+    }
+
+    $handle = fopen($_FILES['csv_file']['tmp_name'], 'r');
+    if (!$handle) {
+        wp_send_json_error(__('Impossible d\'ouvrir le fichier', 'interpeller-son-maire'));
+    }
+
+    $firstLine = fgets($handle);
+    if ($firstLine === false) {
+        fclose($handle);
+        wp_send_json_error(__('Fichier vide', 'interpeller-son-maire'));
+    }
+    $delimiter = substr_count($firstLine, ';') > substr_count($firstLine, ',') ? ';' : ',';
+    $rows = [str_getcsv(trim($firstLine), $delimiter)];
+    while (($data = fgetcsv($handle, 0, $delimiter)) !== false) {
+        $rows[] = $data;
+    }
+    fclose($handle);
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'ism_templates';
+    $imported = 0;
+
+    foreach ($rows as $row) {
+        if (empty(array_filter($row))) {
+            continue;
+        }
+        if (isset($row[0]) && strtolower($row[0]) === 'title') {
+            continue;
+        }
+
+        $title = sanitize_text_field($row[0] ?? '');
+        $subject = sanitize_text_field($row[1] ?? '');
+        $content = isset($row[2]) ? wp_kses_post($row[2]) : '';
+        $category = sanitize_text_field($row[3] ?? 'waste');
+
+        if ($title && $subject && $content) {
+            $wpdb->insert($table, [
+                'title' => $title,
+                'subject' => $subject,
+                'content' => $content,
+                'category' => $category
+            ]);
+            $imported++;
+        }
+    }
+
+    wp_send_json_success(['imported' => $imported]);
+}
+

--- a/templates/admin/templates.php
+++ b/templates/admin/templates.php
@@ -79,7 +79,15 @@ $templates = $wpdb->get_results("SELECT * FROM $table WHERE is_active = 1 ORDER 
     
     <!-- Templates List -->
     <div class="ism-panel">
-        <h3><?php _e('Modèles existants', 'interpeller-son-maire'); ?></h3>
+        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+            <h3><?php _e('Modèles existants', 'interpeller-son-maire'); ?></h3>
+            <div>
+                <button class="ism-btn ism-btn-secondary" onclick="document.getElementById('templates-csv-import').click()">
+                    <?php _e('Importer CSV', 'interpeller-son-maire'); ?>
+                </button>
+                <input type="file" id="templates-csv-import" accept=".csv" style="display: none;">
+            </div>
+        </div>
         
         <?php if (!empty($templates)): ?>
             <div style="display: grid; gap: 1.5rem;">
@@ -150,6 +158,35 @@ jQuery(document).ready(function($) {
                 }
             });
         }
+    });
+
+    $('#templates-csv-import').on('change', function(e) {
+        var file = e.target.files[0];
+        if (!file) return;
+
+        var formData = new FormData();
+        formData.append('csv_file', file);
+        formData.append('action', 'ism_import_templates');
+        formData.append('nonce', '<?php echo wp_create_nonce('ism_import_templates'); ?>');
+
+        $.ajax({
+            url: ajaxurl,
+            method: 'POST',
+            data: formData,
+            processData: false,
+            contentType: false,
+            success: function(response) {
+                if (response.success) {
+                    alert('Import réussi: ' + response.data.imported + ' modèles importés');
+                    location.reload();
+                } else {
+                    alert('Erreur: ' + response.data);
+                }
+            },
+            error: function() {
+                alert('Erreur lors de l\'import');
+            }
+        });
     });
 });
 </script>


### PR DESCRIPTION
## Summary
- allow CSV import of message templates from the admin
- handle template CSV uploads via AJAX

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a436ecca8832bbf4011ea503c4000