### PR TITLE
Add reCAPTCHA initialization

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -18,6 +18,7 @@
             this.communes = [];
             this.templates = [];
             this.searchTimeout = null;
+            this.recaptchaToken = '';
             
             this.init();
         }
@@ -297,18 +298,25 @@
             
             $('#ism-success-message').hide();
             this.form.show();
+
+            this.initRecaptcha();
         }
         
         initRecaptcha() {
-            // Initialize Google reCAPTCHA v3 if configured
-            if (typeof grecaptcha !== 'undefined') {
-                // reCAPTCHA is loaded
+            if (typeof grecaptcha === 'undefined' || !ismAjax.recaptchaSiteKey) {
+                return;
             }
+
+            grecaptcha.ready(() => {
+                grecaptcha.execute(ismAjax.recaptchaSiteKey, { action: 'submit' })
+                    .then((token) => {
+                        this.recaptchaToken = token;
+                    });
+            });
         }
-        
+
         getRecaptchaToken() {
-            // Return reCAPTCHA token if available
-            return 'dummy-token'; // Replace with actual reCAPTCHA implementation
+            return this.recaptchaToken || '';
         }
     }
     

--- a/interpeller-son-maire.php
+++ b/interpeller-son-maire.php
@@ -74,13 +74,27 @@ class InterpellerSonMaire {
     public function enqueueScripts() {
         wp_enqueue_script('ism-frontend', ISM_PLUGIN_URL . 'assets/js/frontend.js', ['jquery'], ISM_PLUGIN_VERSION, true);
         wp_enqueue_style('ism-frontend', ISM_PLUGIN_URL . 'assets/css/frontend.css', [], ISM_PLUGIN_VERSION);
-        
+
+        $settings = get_option('ism_settings', []);
+        $recaptcha_enabled = isset($settings['recaptcha_enabled']) && $settings['recaptcha_enabled'] && defined('ISM_RECAPTCHA_SITE_KEY') && ISM_RECAPTCHA_SITE_KEY;
+
+        if ($recaptcha_enabled) {
+            wp_enqueue_script(
+                'google-recaptcha',
+                'https://www.google.com/recaptcha/api.js?render=' . ISM_RECAPTCHA_SITE_KEY,
+                [],
+                null,
+                true
+            );
+        }
+
         // Localize script
         wp_localize_script('ism-frontend', 'ismAjax', [
             'ajaxurl' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('ism_nonce'),
             'restUrl' => rest_url('interpeller-son-maire/v1/'),
-            'restNonce' => wp_create_nonce('wp_rest')
+            'restNonce' => wp_create_nonce('wp_rest'),
+            'recaptchaSiteKey' => $recaptcha_enabled ? ISM_RECAPTCHA_SITE_KEY : ''
         ]);
     }
     


### PR DESCRIPTION
## Summary
- load Google reCAPTCHA v3 when enabled
- initialize it in `frontend.js` and use its token

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68599f5c58c8832b8e684623bd754c2a