### PR TITLE
Add commune deletion via AJAX

### DIFF
--- a/inc/Admin/AjaxHandler.php
+++ b/inc/Admin/AjaxHandler.php
@@ -6,6 +6,7 @@ defined('ABSPATH') || exit;
 class AjaxHandler {
     public function __construct() {
         add_action('wp_ajax_ism_edit_template', [$this, 'editTemplate']);
+        add_action('wp_ajax_ism_delete_commune', [$this, 'deleteCommune']);
     }
 
     public function editTemplate() {
@@ -35,6 +36,29 @@ class AjaxHandler {
             wp_send_json_success();
         } else {
             wp_send_json_error(__('Update failed', 'interpeller-son-maire'));
+        }
+    }
+
+    public function deleteCommune() {
+        check_ajax_referer('ism_delete_commune', 'nonce');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(__('Permission denied', 'interpeller-son-maire'));
+        }
+
+        if (empty($_POST['commune_id'])) {
+            wp_send_json_error(__('Invalid commune', 'interpeller-son-maire'));
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'ism_communes';
+
+        $deleted = $wpdb->delete($table, ['id' => absint($_POST['commune_id'])]);
+
+        if ($deleted !== false) {
+            wp_send_json_success();
+        } else {
+            wp_send_json_error(__('Delete failed', 'interpeller-son-maire'));
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow deleting communes from admin via new `deleteCommune()` AJAX handler
- hook the new action when initializing the `AjaxHandler`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a54127328832bb5c818925f66321e