### PR TITLE
Implement AJAX deletion for templates

### DIFF
--- a/inc/Admin/AjaxHandler.php
+++ b/inc/Admin/AjaxHandler.php
@@ -7,6 +7,7 @@ class AjaxHandler {
     public function __construct() {
         add_action('wp_ajax_ism_edit_template', [$this, 'editTemplate']);
         add_action('wp_ajax_ism_delete_commune', [$this, 'deleteCommune']);
+        add_action('wp_ajax_ism_delete_template', [$this, 'deleteTemplate']);
     }
 
     public function editTemplate() {
@@ -54,6 +55,29 @@ class AjaxHandler {
         $table = $wpdb->prefix . 'ism_communes';
 
         $deleted = $wpdb->delete($table, ['id' => absint($_POST['commune_id'])]);
+
+        if ($deleted !== false) {
+            wp_send_json_success();
+        } else {
+            wp_send_json_error(__('Delete failed', 'interpeller-son-maire'));
+        }
+    }
+
+    public function deleteTemplate() {
+        check_ajax_referer('ism_delete_template', 'nonce');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(__('Permission denied', 'interpeller-son-maire'));
+        }
+
+        if (empty($_POST['template_id'])) {
+            wp_send_json_error(__('Invalid template', 'interpeller-son-maire'));
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'ism_templates';
+
+        $deleted = $wpdb->delete($table, ['id' => absint($_POST['template_id'])]);
 
         if ($deleted !== false) {
             wp_send_json_success();


### PR DESCRIPTION
## Summary
- enable deletion of templates via AJAX
- add `deleteTemplate` handler

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a5e160c38832bb61a8aaee2c3ad00