### PR TITLE
Allow editing communes

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -19,6 +19,9 @@
             
             // Delete commune
             $('.delete-commune').on('click', (e) => this.handleDeleteCommune(e));
+            $('.edit-commune').on('click', (e) => this.openEditCommune(e));
+            $('#ism-edit-commune-form').on('submit', (e) => this.handleEditCommune(e));
+            $('#ism-edit-commune-cancel').on('click', () => $('#ism-edit-commune-modal').css('display', 'none'));
             
             // Import CSV
             $('#import-csv').on('change', (e) => this.handleImportCSV(e));
@@ -85,6 +88,47 @@
                 },
                 error: () => {
                     alert('Erreur lors de la suppression');
+                }
+            });
+        }
+
+        openEditCommune(e) {
+            e.preventDefault();
+            const btn = $(e.currentTarget);
+            $('#edit_commune_id').val(btn.data('commune-id'));
+            $('#edit_commune_name').val(btn.data('commune-name'));
+            $('#edit_code_insee').val(btn.data('code-insee'));
+            $('#edit_mayor_email').val(btn.data('mayor-email'));
+            $('#edit_population').val(btn.data('population'));
+            $('#edit_region').val(btn.data('region'));
+            $('#ism-edit-commune-modal').css('display', 'flex');
+        }
+
+        handleEditCommune(e) {
+            e.preventDefault();
+
+            $.ajax({
+                url: ajaxurl,
+                method: 'POST',
+                data: {
+                    action: 'ism_edit_commune',
+                    nonce: $('#ism_edit_commune_nonce').val(),
+                    commune_id: $('#edit_commune_id').val(),
+                    commune_name: $('#edit_commune_name').val(),
+                    code_insee: $('#edit_code_insee').val(),
+                    mayor_email: $('#edit_mayor_email').val(),
+                    population: $('#edit_population').val(),
+                    region: $('#edit_region').val()
+                },
+                success: (response) => {
+                    if (response.success) {
+                        location.reload();
+                    } else {
+                        alert('Erreur: ' + response.data);
+                    }
+                },
+                error: () => {
+                    alert('Erreur lors de la mise à jour');
                 }
             });
         }

--- a/inc/Admin/AjaxHandler.php
+++ b/inc/Admin/AjaxHandler.php
@@ -6,6 +6,7 @@ defined('ABSPATH') || exit;
 class AjaxHandler {
     public function __construct() {
         add_action('wp_ajax_ism_edit_template', [$this, 'editTemplate']);
+        add_action('wp_ajax_ism_edit_commune', [$this, 'editCommune']);
         add_action('wp_ajax_ism_delete_commune', [$this, 'deleteCommune']);
         add_action('wp_ajax_ism_delete_template', [$this, 'deleteTemplate']);
     }
@@ -32,6 +33,37 @@ class AjaxHandler {
         ];
 
         $updated = $wpdb->update($table, $data, ['id' => absint($_POST['template_id'])]);
+
+        if ($updated !== false) {
+            wp_send_json_success();
+        } else {
+            wp_send_json_error(__('Update failed', 'interpeller-son-maire'));
+        }
+    }
+
+    public function editCommune() {
+        check_ajax_referer('ism_edit_commune', 'nonce');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(__('Permission denied', 'interpeller-son-maire'));
+        }
+
+        if (empty($_POST['commune_id'])) {
+            wp_send_json_error(__('Invalid commune', 'interpeller-son-maire'));
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'ism_communes';
+
+        $data = [
+            'name' => sanitize_text_field($_POST['commune_name'] ?? ''),
+            'code_insee' => isset($_POST['code_insee']) && $_POST['code_insee'] !== '' ? sanitize_text_field($_POST['code_insee']) : null,
+            'mayor_email' => sanitize_email($_POST['mayor_email'] ?? ''),
+            'population' => isset($_POST['population']) ? absint($_POST['population']) : null,
+            'region' => sanitize_text_field($_POST['region'] ?? '')
+        ];
+
+        $updated = $wpdb->update($table, $data, ['id' => absint($_POST['commune_id'])]);
 
         if ($updated !== false) {
             wp_send_json_success();

--- a/inc/Core/Database.php
+++ b/inc/Core/Database.php
@@ -13,7 +13,7 @@ class Database {
         $sql_communes = "CREATE TABLE $table_communes (
             id mediumint(9) NOT NULL AUTO_INCREMENT,
             name varchar(255) NOT NULL,
-            code_insee varchar(10) NOT NULL,
+            code_insee varchar(10) DEFAULT NULL,
             mayor_email varchar(255) NOT NULL,
             population int(11) DEFAULT 0,
             region varchar(255) DEFAULT '',


### PR DESCRIPTION
## Summary
- allow optional INSEE code when creating tables
- add edit commune endpoint and JS bindings
- add edit commune modal in admin UI
- require only commune name and mayor email when adding

## Testing
- `npm run lint` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a6df1c564832b81cca289a4a1e643